### PR TITLE
Reverting to spring-cloud-gcp-dependencies 5.6.1 due to crash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>spring-cloud-gcp-dependencies</artifactId>
-                <version>5.8.0</version>
+                <version>5.6.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
A separate application was experiencing the following runtime crash when deploying

```
C [libio_grpc_netty_shaded_netty_tcnative_linux_x86_645219058936957356729.so+0x2a154] netty_internal_tcnative_SSLContext_JNI_OnLoad+0x9c4
```

Same issue as https://github.com/UnitVectorY-Labs/ServiceAuthCentral/pull/48